### PR TITLE
게시글 카테고리 API 구현

### DIFF
--- a/src/main/java/com/prgrmsfinal/skypedia/post/controller/PostCategoryController.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/controller/PostCategoryController.java
@@ -1,7 +1,19 @@
 package com.prgrmsfinal.skypedia.post.controller;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryRequestDTO;
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryResponseDTO;
+import com.prgrmsfinal.skypedia.post.service.PostCategoryService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -11,5 +23,22 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/post-category")
 @Tag(name = "게시글 카테고리 API 컨트롤러", description = "게시글 카테고리와 관련된 REST API를 제공하는 컨트롤러입니다.")
 public class PostCategoryController {
+	private final PostCategoryService postCategoryService;
 
+	@GetMapping("/{name}")
+	public PostCategoryResponseDTO.Read read(@PathVariable("name") String name) {
+		return postCategoryService.read(name);
+	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public List<PostCategoryResponseDTO.Read> readAll() {
+		return postCategoryService.readAll();
+	}
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void create(Authentication authentication, PostCategoryRequestDTO.Create request) {
+		postCategoryService.create(authentication, request);
+	}
 }

--- a/src/main/java/com/prgrmsfinal/skypedia/post/dto/PostCategoryRequestDTO.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/dto/PostCategoryRequestDTO.java
@@ -1,0 +1,14 @@
+package com.prgrmsfinal.skypedia.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PostCategoryRequestDTO {
+	@Getter
+	@AllArgsConstructor
+	public static class Create {
+		private final String name;
+
+		private final String description;
+	}
+}

--- a/src/main/java/com/prgrmsfinal/skypedia/post/dto/PostCategoryResponseDTO.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/dto/PostCategoryResponseDTO.java
@@ -1,0 +1,14 @@
+package com.prgrmsfinal.skypedia.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PostCategoryResponseDTO {
+	@Getter
+	@AllArgsConstructor
+	public static class Read {
+		private final String name;
+
+		private final String description;
+	}
+}

--- a/src/main/java/com/prgrmsfinal/skypedia/post/exception/PostError.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/exception/PostError.java
@@ -13,6 +13,7 @@ public enum PostError {
 	NOT_FOUND_USERNAME(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다."),
 	UNAUTHORIZED_CREATE(HttpStatus.UNAUTHORIZED, "게시글 작성 권한이 없습니다."),
 	UNAUTHORIZED_CREATE_REPLY(HttpStatus.UNAUTHORIZED, "게시글에 댓글 작성 권한이 없습니다."),
+	UNAUTHORIZED_CREATE_CATEGORY(HttpStatus.UNAUTHORIZED, "게시글 카테고리 생성 권한이 없습니다."),
 	UNAUTHORIZED_MODIFY(HttpStatus.UNAUTHORIZED, "게시글 수정 권한이 없습니다."),
 	UNAUTHORIZED_DELETE(HttpStatus.UNAUTHORIZED, "게시글 삭제 권한이 없습니다."),
 	UNAUTHORIZED_TOGGLE_LIKES(HttpStatus.UNAUTHORIZED, "좋아요 기능은 회원만 사용 가능합니다."),

--- a/src/main/java/com/prgrmsfinal/skypedia/post/service/PostCategoryService.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/service/PostCategoryService.java
@@ -1,10 +1,21 @@
 package com.prgrmsfinal.skypedia.post.service;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.security.core.Authentication;
+
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryRequestDTO;
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryResponseDTO;
 import com.prgrmsfinal.skypedia.post.entity.PostCategory;
 
 public interface PostCategoryService {
+	PostCategoryResponseDTO.Read read(String name);
+
+	List<PostCategoryResponseDTO.Read> readAll();
+
+	void create(Authentication authentication, PostCategoryRequestDTO.Create request);
+
 	Optional<PostCategory> getByName(String name);
 
 	boolean existsByName(String name);

--- a/src/main/java/com/prgrmsfinal/skypedia/post/service/PostCategoryServiceImpl.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/service/PostCategoryServiceImpl.java
@@ -1,11 +1,17 @@
 package com.prgrmsfinal.skypedia.post.service;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryRequestDTO;
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryResponseDTO;
 import com.prgrmsfinal.skypedia.post.entity.PostCategory;
+import com.prgrmsfinal.skypedia.post.exception.PostError;
 import com.prgrmsfinal.skypedia.post.repository.PostCategoryRepository;
+import com.prgrmsfinal.skypedia.post.util.PostCategoryMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,6 +19,29 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostCategoryServiceImpl implements PostCategoryService {
 	private final PostCategoryRepository postCategoryRepository;
+
+	@Override
+	public PostCategoryResponseDTO.Read read(String name) {
+		PostCategory postCategory = getByName(name)
+			.orElseThrow(PostError.NOT_FOUND_CATEGORY::getException);
+
+		return PostCategoryMapper.toDTO(postCategory);
+	}
+
+	@Override
+	public List<PostCategoryResponseDTO.Read> readAll() {
+		return postCategoryRepository.findAll().stream()
+			.map(PostCategoryMapper::toDTO).toList();
+	}
+
+	@Override
+	public void create(Authentication authentication, PostCategoryRequestDTO.Create request) {
+		if (!authentication.isAuthenticated()) {
+			throw PostError.UNAUTHORIZED_CREATE_CATEGORY.getException();
+		}
+
+		postCategoryRepository.save(PostCategoryMapper.toEntity(request));
+	}
 
 	@Override
 	public Optional<PostCategory> getByName(String name) {

--- a/src/main/java/com/prgrmsfinal/skypedia/post/util/PostCategoryMapper.java
+++ b/src/main/java/com/prgrmsfinal/skypedia/post/util/PostCategoryMapper.java
@@ -1,0 +1,18 @@
+package com.prgrmsfinal.skypedia.post.util;
+
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryRequestDTO;
+import com.prgrmsfinal.skypedia.post.dto.PostCategoryResponseDTO;
+import com.prgrmsfinal.skypedia.post.entity.PostCategory;
+
+public class PostCategoryMapper {
+	public static PostCategoryResponseDTO.Read toDTO(PostCategory postCategory) {
+		return new PostCategoryResponseDTO.Read(postCategory.getName(), postCategory.getDescription());
+	}
+
+	public static PostCategory toEntity(PostCategoryRequestDTO.Create dto) {
+		return PostCategory.builder()
+			.name(dto.getName())
+			.description(dto.getDescription())
+			.build();
+	}
+}


### PR DESCRIPTION
## ☑️ PR 유형
-  새로운 기능 추가


## 📝 작업 내용
게시글 카테고리 생성, 단일 조회, 목록 조회 API를 구현했습니다.

## ✅ 피드백 반영사항
자세한 내용은 커밋 메시지를 참고해주세요.

## 💬 리뷰 요구사항
.
